### PR TITLE
Audit improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,26 @@ Argon2 (with Argon2u support) run as WebAssembly.
 
 ```
 > let argon2 = require('.');
-> argon2({pass: 'password', salt: 'somesalt', distPath: 'dist'}).then(console.log);
+> argon2.hash({pass: 'password', salt: 'somesalt', distPath: 'dist'}).then(console.log);
 { hash:
    Uint8Array [ ... ],
   hashHex:
    'f38afe1266d247cf1f6f836ffdbb0ab946c0a7edbcb4ba6e7324b32b9050441e',
   encoded:
    '$argon2d$v=19$m=1024,t=10,p=1$c29tZXNhbHQ$84r+EmbSR88fb4Nv/bsKuUbAp+28tLpucySzK5BQRB4' }
+```
+
+The input object has the following parameters and defaults:
+
+```
+{string}  pass                password string
+{string}  salt                salt string
+{float}   time        (1)     the number of iterations
+{float}   mem         (1024)  used memory, in KiB
+{float}   hashLen     (24)    desired hash length
+{float}   parallelism (1)     desired parallelism (will be computed in parallel only for PNaCl)
+{number}  type        (argon2.types.Argon2d)   hash type: argon2.ArgonType.Argon2d, .Argon2i, .Argon2id or .Argon2u
+{string}  distPath    ('.')   asm.js script location, without trailing slash
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Argon2 (with Argon2u support) run as WebAssembly.
 
 ```
 > let argon2 = require('.');
-> argon2({password:'password',salt:'somesalt',distPath:'dist'}).then(console.log);
+> argon2({pass: 'password', salt: 'somesalt', distPath: 'dist'}).then(console.log);
 { hash:
    Uint8Array [ ... ],
   hashHex:

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ var Module = {
 * @param {float}  [params.mem=1024] - used memory, in KiB
 * @param {float}  [params.hashLen=24] - desired hash length
 * @param {float}  [params.parallelism=1] - desired parallelism (will be computed in parallel only for PNaCl)
-* @param {number} [params.distPath=.] - asm.js script location, without trailing slash
 * @param {number} [params.type=argon2.types.Argon2d] - hash type: argon2.ArgonType.Argon2d, .Argon2i, .Argon2id or .Argon2u
+* @param {string} [params.distPath=.] - asm.js script location, without trailing slash
 *
 * @return Promise
 *

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ var Module = {
 * @param {float}  [params.mem=1024] - used memory, in KiB
 * @param {float}  [params.hashLen=24] - desired hash length
 * @param {float}  [params.parallelism=1] - desired parallelism (will be computed in parallel only for PNaCl)
-* @param {number} [params.type=argon2.ArgonType.Argon2d] - hash type: argon2.ArgonType.Argon2d, .Argon2i, .Argon2id or .Argon2u
 * @param {number} [params.distPath=.] - asm.js script location, without trailing slash
+* @param {number} [params.type=argon2.types.Argon2d] - hash type: argon2.ArgonType.Argon2d, .Argon2i, .Argon2id or .Argon2u
 *
 * @return Promise
 *
@@ -125,4 +125,12 @@ function allocateArray(strOrArr) {
   return Module.allocate(arr, 'i8', Module.ALLOC_NORMAL);
 }
 
-module.exports = argon2;
+module.exports = {
+  hash: argon2,
+  types: {
+    Argon2d: 0,
+    Argon2i: 1,
+    Argon2id: 2,
+    Argon2u: 10
+  }
+}


### PR DESCRIPTION
Not sure what's standard/acceptable here, but we really should provide enums for the magic numbers that are argon2 type configuration. This seems okay to me, maybe there's something tidier I can do.

For ease of use, I copied the most important docstrings into the readme.

This does change the interface of the library. I will update dependents (just keygen-js I'm pretty sure) once this has been merged.